### PR TITLE
chore: npm version patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
-          yarn lerna publish from-package --yes --no-private
+          yarn lerna publish from-package --yes --no-private --no-git-tag-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Bump & Publish
+name: Publish & Release
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   merged:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged && startsWith(github.head_ref, 'release/assinents')
     runs-on: ubuntu-latest
 
     steps:
@@ -28,16 +28,28 @@ jobs:
           yarn install --immutable 
           yarn lerna run build
 
-      - name: Versioning changed packages
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com  
-          yarn lerna version patch --yes --conventional-commits --no-git-tag-version
-
-          npm version patch
-
       - name: Publish changed packages to npm registry
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
           yarn lerna publish from-package --yes --no-private --no-git-tag-version
+
+      - name: Create assinents git tag
+        id: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=`node -p "require('./packages/assignments/package.json').version"`
+          git tag assignments@$VERSION
+          git push origin assignments@$VERSION
+          echo "::set-output name=version::$VERSION"
+
+      - name: Create GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: assinents@${{ steps.tag.outputs.version }}
+          release_name: Release assinents@${{ steps.tag.outputs.version }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com  
-          yarn lerna version patch --yes --conventional-commits
+          yarn lerna version patch --yes --conventional-commits --no-git-tag-version
+
+          npm version patch
 
       - name: Publish changed packages to npm registry
         env:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "new": "hygen component new && yarn"
+    "new": "hygen component new && yarn",
+    "version": "yarn lerna version --conventional-commits --no-git-tag-version",
+    "version-root": "npm version"
   },
   "author": "sjoleee",
   "license": "ISC",


### PR DESCRIPTION
## 수정본
브랜치 파서 열심히 작업 후 `main`으로 pr올려서 머지합니다.
이제 지금까지 열심히 작업한것들을 모아서 버전업, npm배포 및 릴리즈가 하고싶다?! 그럼 요 ci를 사용하게 됩니다.

- `release/assinents` 로 시작하는 브랜치를 하나 만듭니다. ex. `release/assinents-tooltip`
- 루트에서 `yarn run version` 커맨드로 버전업을 해줍니다.
	- 요녀석은 이전 릴리즈를 기준으로 변경점이 있는 패키지들을 쫙~ 찾아서 다 버전업을 해줍니다.
	- 이때, 각 패키지마다 major, minor, patch 중에서 어떤 버전업을 할건지 정할 수 있습니다.
- 자동으로 푸시까지 해줍니다. 그대로 `release` 브랜치를 원격에 올리고 release pr을 `main`으로 보내주세요
- release pr이 머지되면 ci가 동작합니다.  ci가 해주는것은 아래와 같습니다.
	- `yarn lerna publish`를 사용해 npm에 배포된 버전과 pkgJson에 등록된 버전이 다른 패키지들을 쭉 찾아서 전부 npm 배포해줍니다
	- 이때, 컴포넌트가 수정됐다는건 `assinents`도 버전업이 된다는 뜻이므로 `assinents`는 반드시 버전이 올라갔을것이고, npm에 배포될 것입니다.
	- 이 `assinents`의 새로운 버전을 기준으로 git tag를 생성해줍니다. ex. `assinents@1.1.1`
	- 생성된 git tag를 기준으로 release를 자동으로 진행합니다. ex. `Release assinents@1.1.1`

이런 절차로 release를 반쯤... 자동화 할 수 있을 것 같습니다~ 짜잔~